### PR TITLE
Fix URL parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
- hlo: HTTP  Server Utilities
+  hlo: HTTP  Server Utilities
 =========
 
 ## What are they

--- a/src/core/support/parsed_url.cc
+++ b/src/core/support/parsed_url.cc
@@ -97,7 +97,7 @@ int32_t parsed_url::parse(const std::string &a_url)
 	std::string l_uri_str;
 	std::string l_host_str;
 	// Get up to end of string or /
-	l_uri_str = a_url.substr(l_prefix_pos + strlen(""), a_url.length());
+	l_uri_str = a_url.substr(l_prefix_pos);
 	//NDBG_PRINT("PATH: uri: %s\n", l_uri_str.c_str());
 
 	size_t l_host_slash_pos = 0;
@@ -111,9 +111,16 @@ int32_t parsed_url::parse(const std::string &a_url)
 	}
 	else
 	{
-		l_host_str = l_uri_str;
+        // A quick hack for situation that option is followed by a URL
+        // which doesn't have a path component here
+        std::size_t ret = l_uri_str.find(";",0);
+        if( ret != std::string::npos ) {
+            m_path = l_uri_str.substr(ret);
+            l_host_str = l_uri_str.substr(0,ret);
+        } else {
+            l_host_str = l_uri_str;
+        }
 	}
-
 
 	// -----------------------------------------------------
 	// port

--- a/src/core/support/reqlet.cc
+++ b/src/core/support/reqlet.cc
@@ -298,30 +298,33 @@ int32_t reqlet::special_effects_parse(void)
         char *l_save_ptr;
         strncpy(l_path, m_url.m_path.c_str(), 2048);
         char *l_p = strtok_r(l_path, SPECIAL_EFX_OPT_SEPARATOR, &l_save_ptr);
-        //printf("Path: %s\n", l_p);
-        m_url.m_path = l_p;
 
-        int32_t l_status;
-        path_substr_vector_t l_path_substr_vector;
-        range_vector_t l_range_vector;
-        if(l_p)
-        {
+        if( m_url.m_path.front() != *SPECIAL_EFX_OPT_SEPARATOR ) {
+            // Rule out special cases that m_path only contains options
+            //
+            m_url.m_path = l_p;
+
+            int32_t l_status;
+            path_substr_vector_t l_path_substr_vector;
+            range_vector_t l_range_vector;
+            if(l_p)
+            {
                 l_status = parse_path(l_p, l_path_substr_vector, l_range_vector);
                 if(l_status != STATUS_OK)
                 {
-                        NDBG_PRINT("STATUS_ERROR: Performing parse_path(%s)\n", l_p);
-                        return STATUS_ERROR;
+                    NDBG_PRINT("STATUS_ERROR: Performing parse_path(%s)\n", l_p);
+                    return STATUS_ERROR;
                 }
-        }
+            }
 
-        // If empty path explode
-        if(l_range_vector.size())
-        {
+            // If empty path explode
+            if(l_range_vector.size())
+            {
                 l_status = path_exploder(std::string(""), l_path_substr_vector, 0, l_range_vector, 0);
                 if(l_status != STATUS_OK)
                 {
-                        NDBG_PRINT("STATUS_ERROR: Performing explode_path(%s)\n", l_p);
-                        return STATUS_ERROR;
+                    NDBG_PRINT("STATUS_ERROR: Performing explode_path(%s)\n", l_p);
+                    return STATUS_ERROR;
                 }
 
                 // DEBUG show paths
@@ -333,16 +336,17 @@ int32_t reqlet::special_effects_parse(void)
                 //{
                 //      NDBG_OUTPUT(": [%6d]: %s\n", i_path_cnt, i_path->c_str());
                 //}
-        } else {
-
+            } else {
                 m_path_vector.push_back(m_url.m_path);
-
+            }
+            l_p = strtok_r(NULL, SPECIAL_EFX_OPT_SEPARATOR, &l_save_ptr);
+        } else {
+            m_url.m_path.clear();
         }
 
         // Options...
         while (l_p)
         {
-                l_p = strtok_r(NULL, SPECIAL_EFX_OPT_SEPARATOR, &l_save_ptr);
                 if(l_p)
                 {
                         char l_options[1024];
@@ -367,6 +371,7 @@ int32_t reqlet::special_effects_parse(void)
                         //printf("Val: %s\n", l_v);
 
                 }
+                l_p = strtok_r(NULL, SPECIAL_EFX_OPT_SEPARATOR, &l_save_ptr);
         }
 
 


### PR DESCRIPTION
When URL doesn't comes with path but has a component, then hlo will incorrectly make the option become part of the host name and failed to parse the options.